### PR TITLE
Set standard network tier as default 

### DIFF
--- a/ubnt-vm-main.tf
+++ b/ubnt-vm-main.tf
@@ -51,6 +51,7 @@ resource "google_compute_instance" "gcp-ubnt-vm" {
     network       = google_compute_network.vpc.name
     subnetwork    = google_compute_subnetwork.network_subnet.name
     access_config {
+      network_tier = "STANDARD"
     }
   }
 


### PR DESCRIPTION
This parameter is now supported 
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#network_tier-1
This avoids having to edit the option after deployment to ensure the entire setup remains free.